### PR TITLE
Add nil public access test and fix for IsBucketPublic

### DIFF
--- a/internal/awsutils/s3.go
+++ b/internal/awsutils/s3.go
@@ -64,7 +64,11 @@ func IsBucketPublic(s3Client S3ClientAPI, bucketName string) (bool, error) {
 	})
 	if err == nil {
 		config := pabOutput.PublicAccessBlockConfiguration
-		if config != nil && *config.BlockPublicAcls && *config.BlockPublicPolicy && *config.IgnorePublicAcls && *config.RestrictPublicBuckets {
+		if config != nil &&
+			aws.ToBool(config.BlockPublicAcls) &&
+			aws.ToBool(config.BlockPublicPolicy) &&
+			aws.ToBool(config.IgnorePublicAcls) &&
+			aws.ToBool(config.RestrictPublicBuckets) {
 			return false, nil
 		}
 	}

--- a/internal/awsutils/s3_test.go
+++ b/internal/awsutils/s3_test.go
@@ -215,6 +215,22 @@ func TestIsBucketPublic(t *testing.T) {
 			expectedValue: true,
 			expectError:   false,
 		},
+		{
+			name:       "Bucket with nil public access config",
+			bucketName: "partial-config-bucket",
+			mockSetup: func(m *mockS3Client) {
+				m.On("GetPublicAccessBlock", mock.Anything, mock.Anything).Return(
+					&s3.GetPublicAccessBlockOutput{
+						PublicAccessBlockConfiguration: &types.PublicAccessBlockConfiguration{},
+					}, nil)
+				m.On("GetBucketAcl", mock.Anything, mock.Anything).Return(
+					&s3.GetBucketAclOutput{
+						Grants: []types.Grant{},
+					}, nil)
+			},
+			expectedValue: false,
+			expectError:   false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- handle nil PublicAccessBlockConfiguration fields
- test IsBucketPublic with a nil configuration struct

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6858dbb71d58832db95b17da3ce0c6d5