### PR TITLE
Fix IsBucketPublic checks

### DIFF
--- a/internal/awsutils/s3.go
+++ b/internal/awsutils/s3.go
@@ -64,7 +64,11 @@ func IsBucketPublic(s3Client S3ClientAPI, bucketName string) (bool, error) {
 	})
 	if err == nil {
 		config := pabOutput.PublicAccessBlockConfiguration
-		if config != nil && *config.BlockPublicAcls && *config.BlockPublicPolicy && *config.IgnorePublicAcls && *config.RestrictPublicBuckets {
+		if config != nil &&
+			config.BlockPublicAcls != nil && *config.BlockPublicAcls &&
+			config.BlockPublicPolicy != nil && *config.BlockPublicPolicy &&
+			config.IgnorePublicAcls != nil && *config.IgnorePublicAcls &&
+			config.RestrictPublicBuckets != nil && *config.RestrictPublicBuckets {
 			return false, nil
 		}
 	}

--- a/internal/awsutils/s3_test.go
+++ b/internal/awsutils/s3_test.go
@@ -215,6 +215,25 @@ func TestIsBucketPublic(t *testing.T) {
 			expectedValue: true,
 			expectError:   false,
 		},
+		{
+			name:       "Bucket with incomplete public access block",
+			bucketName: "partial-block-bucket",
+			mockSetup: func(m *mockS3Client) {
+				m.On("GetPublicAccessBlock", mock.Anything, mock.Anything).Return(
+					&s3.GetPublicAccessBlockOutput{
+						PublicAccessBlockConfiguration: &types.PublicAccessBlockConfiguration{
+							BlockPublicAcls: aws.Bool(true),
+							// BlockPublicPolicy missing
+							IgnorePublicAcls:      aws.Bool(true),
+							RestrictPublicBuckets: aws.Bool(true),
+						},
+					}, nil)
+				m.On("GetBucketAcl", mock.Anything, mock.Anything).Return(
+					&s3.GetBucketAclOutput{}, nil)
+			},
+			expectedValue: false,
+			expectError:   false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- avoid nil dereferences in IsBucketPublic
- add test for incomplete public access block configuration